### PR TITLE
Fix clang/g++ compilation issues

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -5,7 +5,7 @@ TARGET   = packJPG
 CC       = gcc
 CPP      = g++
 RC       = windres -O coff
-CPPFLAGS = -I. -O3 -Wall -pedantic -funroll-loops -ffast-math -fsched-spec-load -fomit-frame-pointer
+CPPFLAGS = -I. -O3 -Wall -pedantic -funroll-loops -ffast-math -fsched-spec-load -fomit-frame-pointer -std=c++14
 LDFLAGS  = -static -static-libgcc -static-libstdc++
 CSRC     = $(wildcard *.c)
 CPPSRC   = $(wildcard *.cpp)

--- a/source/Makefile_osx
+++ b/source/Makefile_osx
@@ -5,7 +5,7 @@
 CC      = cc
 CPP     = c++
 RC      = windres
-CFLAGS  = -I. -DUNIX -DDEV_BUILD -O3 -Wall -pedantic -funroll-loops -ffast-math -fomit-frame-pointer
+CFLAGS  = -I. -DUNIX -DDEV_BUILD -O3 -Wall -pedantic -funroll-loops -ffast-math -fomit-frame-pointer -std=c++14
 LDFLAGS = 
 DEPS    = bitops.h aricoder.h pjpgtbl.h dct8x8.h Makefile
 OBJ     = bitops.o aricoder.o packjpg.o
@@ -19,4 +19,4 @@ $(BIN): $(OBJ)
 	$(CPP) -o $@ $^ $(LDFLAGS)
 
 clean:
-	$(RM) $(OBJ)
+	$(RM) $(OBJ) $(BIN)

--- a/source/bitops.cpp
+++ b/source/bitops.cpp
@@ -7,7 +7,7 @@ reading and writing of arrays
 
 #include <algorithm>
 #include <array>
-#include <stdio.h>
+#include <cstdio>
 #include <stdlib.h>
 #include <vector>
 
@@ -246,7 +246,7 @@ void abitwriter::write( unsigned int val, int nbits )
 			return;
 		}
 		dsize *= 2;
-		std::fill(data + cbyte + 1, data + dsize, unsigned char(0));
+		std::fill(data + cbyte + 1, data + dsize, static_cast<unsigned char>(0));
 	}
 	
 	// write data
@@ -284,7 +284,7 @@ void abitwriter::write_bit( unsigned char bit )
 				return;
 			}
 			dsize *= 2;
-			std::fill(data + cbyte + 1, data + dsize, unsigned char(0));
+			std::fill(data + cbyte + 1, data + dsize, static_cast<unsigned char>(0));
 		}
 		cbit = 8;
 	} 


### PR DESCRIPTION
Fixes the issues present in #7 and #10 :

1. Adds -std=c++14 to makefile_osx (separately adds the binary to the make clean command)
2. Adds -std=c++14 to makefile
3. Replaces stdio.h with cstdio and replaces function-style casts (which are apparently not fully supported on clang/g++) with static_cast.